### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/jamesmoore/autogram-solver/security/code-scanning/1](https://github.com/jamesmoore/autogram-solver/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow, specifying the least privilege required. Since the workflow only checks out code and runs build/test steps, it only needs read access to repository contents. The best way to do this is to add a `permissions` block at the root level of the workflow file (above the `jobs:` key), setting `contents: read`. This ensures that all jobs in the workflow inherit these minimal permissions unless overridden. No additional imports or definitions are needed; just a single YAML block addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
