### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,8 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/jamesmoore/autogram-solver/security/code-scanning/2](https://github.com/jamesmoore/autogram-solver/security/code-scanning/2)

To fix the problem, add a `permissions` block to the `build` job in the workflow file `.github/workflows/docker-publish.yml`. The minimal required permission for a build job that only checks out code and runs tests is typically `contents: read`. This change should be made by inserting the following lines under the `build:` job definition, before `runs-on: ubuntu-latest` (i.e., after line 24):

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed, as this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
