### PR TITLE
Fix pluralized character naming

### DIFF
--- a/Autogram/CharExtensions.cs
+++ b/Autogram/CharExtensions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Autogram
 {
-    internal static class CharExtensions
+    public static class CharExtensions
     {
         public static string GetCharacterName(this char character)
         {
@@ -17,7 +17,7 @@
             if (character == '-') return "hyphens";
             if (character == '\'') return "apostrophes";
             if (character == ' ') return "spaces";
-            return character + "\'s";
+            return character + "'s";
         }
 
         public static string GetCharacterName(this char character, int numberOf)

--- a/AutogramTest/CharExtensionsTests.cs
+++ b/AutogramTest/CharExtensionsTests.cs
@@ -1,0 +1,58 @@
+using Autogram;
+
+namespace AutogramTest
+{
+    public class CharExtensionsTests
+    {
+        [Theory]
+        [InlineData(',', "comma")]
+        [InlineData('-', "hyphen")]
+        [InlineData('\'', "apostrophe")]
+        [InlineData(' ', "space")]
+        [InlineData('a', "a")]
+        public void GetCharacterName_ReturnsExpectedName(char character, string expected)
+        {
+            var result = character.GetCharacterName();
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(',', "commas")]
+        [InlineData('-', "hyphens")]
+        [InlineData('\'', "apostrophes")]
+        [InlineData(' ', "spaces")]
+        [InlineData('a', "a's")]
+        public void GetPluralisedCharacterName_ReturnsExpectedName(char character, string expected)
+        {
+            var result = character.GetPluralisedCharacterName();
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData('a', 1, "a")]
+        [InlineData('a', 2, "a's")]
+        [InlineData(' ', 1, "space")]
+        [InlineData(' ', 3, "spaces")]
+        public void GetCharacterName_WithCount_ReturnsExpected(char character, int count, string expected)
+        {
+            var result = character.GetCharacterName(count);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData('a', false)]
+        [InlineData(',', true)]
+        public void HasExtendedName_ReturnsExpected(char character, bool expected)
+        {
+            var result = character.HasExtendedName();
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void GetPluralisedCharacterName_ReturnsApostropheSWithoutBackslash()
+        {
+            var result = 'a'.GetPluralisedCharacterName();
+            Assert.Equal("a's", result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- prevent escaped apostrophes from showing in plural character names
- add tests for all CharExtensions helpers
- expose CharExtensions publicly and invoke helpers directly from tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cd471bf18832fa3768b02a7544fe9