### PR TITLE
reduce ByteHistoryKey64 allocations

### DIFF
--- a/Autogram/AutogramBytesNoStringsV5d.cs
+++ b/Autogram/AutogramBytesNoStringsV5d.cs
@@ -66,9 +66,8 @@ namespace Autogram
             else
             {
                 computedCounts.CopyTo(proposedCounts);
+                history.Add(new ByteHistoryKey64(proposedCounts));
             }
-
-            history.Add(new ByteHistoryKey64(proposedCounts));
 
             UpdateComputedCounts();
 
@@ -133,8 +132,10 @@ namespace Autogram
                         : OffsetGuess(computedCount, variableMinimumCount[i], randomizationLevel);
                 }
 
-                if (history.Contains(new ByteHistoryKey64(proposedCounts)) == false)
+                ByteHistoryKey64 proposedKey = new(proposedCounts);
+                if (history.Contains(proposedKey) == false)
                 {
+                    history.Add(proposedKey);
                     return;
                 }
 


### PR DESCRIPTION
Store BaseHistoryKey64 at point of randomization to avoid doing it twice. 